### PR TITLE
Escape spaces in paths in directories in the classpath in the generated Manifest file

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ build.gradle snippet to use ManifestClasspath plugin
 ##### Build script snippet for plugins DSL for Gradle 2.1 and later
 ```
 plugins {
-  id "com.github.ManifestClasspath" version "0.1.0-RELEASE"
+  id "com.github.ManifestClasspath" version "0.2.0-RELEASE"
 }
 ```
 ##### Build script snippet for use in older Gradle versions or where dynamic configuration is required
@@ -26,7 +26,7 @@ buildscript {
     }
   }
   dependencies {
-    classpath "gradle.plugin.com.github.viswaramamoorthy:gradle-util-plugins:0.1.0-RELEASE"
+    classpath "gradle.plugin.com.github.viswaramamoorthy:gradle-util-plugins:0.2.0-RELEASE"
   }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ apply plugin: 'io.codearte.nexus-staging'
 apply plugin: 'com.gradle.plugin-publish'
 
 group = 'com.github.viswaramamoorthy'
-version = '0.1.0-RELEASE'
+version = '0.2.0-RELEASE'
 
 sourceCompatibility = 1.8
 

--- a/src/main/groovy/vr/util/ManifestUtil.groovy
+++ b/src/main/groovy/vr/util/ManifestUtil.groovy
@@ -34,9 +34,21 @@ class ManifestUtil
         if (!fileCollection)
             return
         def classPathString = fileCollection.files.collect {
-                                it.toURL().toString()
+                                toClassPathEntry(it)
                               }.join(' ')
         createManifestJar(jarFile, manifestWithClasspath(classPathString))
+    }
+
+    /**
+     * Convert a file to its URL, with any spaces in the path replaced by {@ %20} so that directories
+     * containing spaces in their names in the classpath will be properly processed when running.
+     *
+     * @param element file to convert to string for inclusion in classpath
+     * @return classpath string referencing given file, as described
+     */
+    private static String toClassPathEntry(File element) {
+        String path = element.toURL().toString()
+        return path.replaceAll(' ', '%20')
     }
 
     private static def createManifestJar(def jarFile, def manifest = null) throws IOException {


### PR DESCRIPTION
I had been using this plugin very successfully to work around Windows path length limitations in my Kotlin project, and was surprised when a clean checkout of my project failed to run on a new machine.  Eventually, I cracked open the mfjars classpath jar which was being used to launch the program and looked at the Class-Path in the Manifest.MF file.  I noticed there were spaces in the paths (the user name on this new machine is "FirstName LastName") which were causing the issue.

I did some testing with a local build of this plugin, and if it converts any spaces in the paths to the URL space escape charactor %20 it will fix this issue.  I also bumped the version to 0.2.0 to reflect the change.

Can you please merge and publish?  Thank you for all your work on this, it was very useful to find such an easy solution for that issue.